### PR TITLE
Add hyperlink to App Store and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
-# Carry Through COVID
+# Carry Through COVID - Landing Page
 
 > A place for business to list their offerings, and consumers to find what is available.
 
-This is a Gatsby app that builds content from the ![ctc-api](https://github.com/carrythroughcovid/ctc-api). Businesses can list their business and offerings through the web experience, and consumers can find businesses around them that are still operating.
+This is a Gatsby app that builds content from the [ctc-api](https://github.com/carrythroughcovid/ctc-api). Businesses can list their business and offerings through the web experience, and consumers can find businesses around them that are still operating.
 
 ## Dependencies
 
-- ![Nodejs](https://nodejs.org/en/download/)
-- ![Yarn](https://classic.yarnpkg.com/en/docs/install/)
+- [Nodejs](https://nodejs.org/en/download/)
+- [Yarn](https://classic.yarnpkg.com/en/docs/install/)
 
 ## Running locally
 
 Clone repo:
 
 ```sh
-git clone https://github.com/carrythroughcovid/ctc-web
+git clone https://github.com/carrythroughcovid/ctc-app-landing
 ```
 
 Change into directory:
 
 ```sh
-cd ctc-web
+cd ctc-app-landing
 ```
 
 Install dependencies:

--- a/src/components/about/AboutHeader.js
+++ b/src/components/about/AboutHeader.js
@@ -13,7 +13,8 @@ const AltSub = styled.div`
   color: ${({ theme }) => theme.colour.accent2};
 `
 
-const AppstoreContainer = styled.div`
+const AppstoreContainer = styled.a`
+  display: block;
   height: 1rem;
 `
 
@@ -33,7 +34,10 @@ const Actions = () => (
     <Button to="/signup" secondary large fixedWidth>
       Sign up now
     </Button>
-    <AppstoreContainer>
+    <AppstoreContainer
+      href="https://apps.apple.com/us/app/carry/id1507935945"
+      target="_blank"
+    >
       <Logo />
     </AppstoreContainer>
   </>


### PR DESCRIPTION
## High-level overview

- Change App Store logo container to `a` tag and add link to [Carry on App Store](https://apps.apple.com/us/app/carry/id1507935945)
- Change references of `ctc-web` to `ctc-app-landing` in README
- Fix typo in README causing links to be images